### PR TITLE
Make sure the regex-match is a word.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function(content, ...rest) {
   const cssModuleInterfaceFilename = filenameToTypingsFilename(filename);
   const { read, write } = makeFileHandlers(cssModuleInterfaceFilename);
 
-  const keyRegex = /"([^\\"]+)":/g;
+  const keyRegex = /"([^\\"]+\w)":/g;
   let match;
   const cssModuleKeys = [];
 


### PR DESCRIPTION
I had a problem when using an import postcss plugin because the actual regex matches spaces. I changed the regex to don't match spaces.