### PR TITLE
fix(deps): Add missing 'loader-utils' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/seek-oss/css-modules-typescript-loader#readme",
   "dependencies": {
-    "line-diff": "^2.0.1"
+    "line-diff": "^2.0.1",
+    "loader-utils: "^1.2.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/seek-oss/css-modules-typescript-loader#readme",
   "dependencies": {
     "line-diff": "^2.0.1",
-    "loader-utils: "^1.2.3"
+    "loader-utils": "^1.2.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",


### PR DESCRIPTION
Currently [index.js](https://github.com/seek-oss/css-modules-typescript-loader/blob/master/index.js#L3) requires `'loader-utils'` without having it as a dependency in `package.json`.