### PR TITLE
fix: Adding css-loader v4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,14 @@ const makeFileHandlers = filename => ({
     fs.writeFile(filename, content, { encoding: 'utf-8' }, handler)
 });
 
+const extractLocalExports = (content) => {
+  let localExports = content.split('exports.locals')[1];
+  if (!localExports) {
+    localExports = content.split('___CSS_LOADER_EXPORT___.locals')[1];
+  }
+  return localExports;
+}
+
 module.exports = function(content, ...rest) {
   const { failed, success } = makeDoneHandlers(this.async(), content, rest);
 
@@ -80,7 +88,7 @@ module.exports = function(content, ...rest) {
   let match;
   const cssModuleKeys = [];
 
-  const localExports = content.split('exports.locals')[1];
+  const localExports = extractLocalExports(content);
 
   while ((match = keyRegex.exec(localExports))) {
     if (cssModuleKeys.indexOf(match[1]) < 0) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@commitlint/cli": "^7.2.1",
     "commitizen": "^3.0.2",
     "commitlint-config-seek": "^1.0.0",
-    "css-loader": "^1.0.0",
+    "css-loader": "^4.2.1",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^1.1.2",
     "jest": "^24.7.1",


### PR DESCRIPTION
**What is it for?**

Currently, the library only supports css-loader up to version 3. From version 4, the local export becomes ___CSS_LOADER_EXPORT___.locals instead of exports.locals. I would like to add the support for version 4. This is the fix for issue number 39: https://github.com/seek-oss/css-modules-typescript-loader/issues/39

**What have I done?**

Added the function to split content with ___CSS_LOADER_EXPORT___.locals if splitting with exports.local fails. Then use the function instead.

Updated the css-loader version for testing.